### PR TITLE
新增隐藏推荐页顶部热门推荐 && 支持 9.37.0

### DIFF
--- a/app/src/main/java/com/shatyuka/zhiliao/Hooks.java
+++ b/app/src/main/java/com/shatyuka/zhiliao/Hooks.java
@@ -11,6 +11,7 @@ import com.shatyuka.zhiliao.hooks.CommentAd;
 import com.shatyuka.zhiliao.hooks.CustomFilter;
 import com.shatyuka.zhiliao.hooks.ExternLink;
 import com.shatyuka.zhiliao.hooks.FeedAd;
+import com.shatyuka.zhiliao.hooks.FeedTopHotBanner;
 import com.shatyuka.zhiliao.hooks.Horizontal;
 import com.shatyuka.zhiliao.hooks.HotBanner;
 import com.shatyuka.zhiliao.hooks.IHook;
@@ -58,6 +59,7 @@ public class Hooks {
             new NavRes(),
             new WebView(),
             new Cleaner(),
+            new FeedTopHotBanner()
     };
 
     public static void init(final ClassLoader classLoader) {

--- a/app/src/main/java/com/shatyuka/zhiliao/Hooks.java
+++ b/app/src/main/java/com/shatyuka/zhiliao/Hooks.java
@@ -12,6 +12,7 @@ import com.shatyuka.zhiliao.hooks.CustomFilter;
 import com.shatyuka.zhiliao.hooks.ExternLink;
 import com.shatyuka.zhiliao.hooks.FeedAd;
 import com.shatyuka.zhiliao.hooks.FeedTopHotBanner;
+import com.shatyuka.zhiliao.hooks.HeadZoneBanner;
 import com.shatyuka.zhiliao.hooks.Horizontal;
 import com.shatyuka.zhiliao.hooks.HotBanner;
 import com.shatyuka.zhiliao.hooks.IHook;
@@ -59,7 +60,8 @@ public class Hooks {
             new NavRes(),
             new WebView(),
             new Cleaner(),
-            new FeedTopHotBanner()
+            new FeedTopHotBanner(),
+            new HeadZoneBanner()
     };
 
     public static void init(final ClassLoader classLoader) {
@@ -70,6 +72,7 @@ public class Hooks {
             } catch (Throwable e) {
                 Helper.toast(hook.getName() + "功能加载失败，可能不支持当前版本知乎: " + Helper.packageInfo.versionName, Toast.LENGTH_LONG);
                 XposedBridge.log("[Zhiliao] " + e);
+                XposedBridge.log(e);
             }
         }
     }

--- a/app/src/main/java/com/shatyuka/zhiliao/Hooks.java
+++ b/app/src/main/java/com/shatyuka/zhiliao/Hooks.java
@@ -9,6 +9,7 @@ import com.shatyuka.zhiliao.hooks.Cleaner;
 import com.shatyuka.zhiliao.hooks.ColorMode;
 import com.shatyuka.zhiliao.hooks.CommentAd;
 import com.shatyuka.zhiliao.hooks.CustomFilter;
+import com.shatyuka.zhiliao.hooks.CustomTabFilter;
 import com.shatyuka.zhiliao.hooks.ExternLink;
 import com.shatyuka.zhiliao.hooks.FeedAd;
 import com.shatyuka.zhiliao.hooks.FeedTopHotBanner;
@@ -63,7 +64,8 @@ public class Hooks {
             new Cleaner(),
             new FeedTopHotBanner(),
             new HeadZoneBanner(),
-            new MineHybridView()
+            new MineHybridView(),
+            new CustomTabFilter(),
     };
 
     public static void init(final ClassLoader classLoader) {

--- a/app/src/main/java/com/shatyuka/zhiliao/Hooks.java
+++ b/app/src/main/java/com/shatyuka/zhiliao/Hooks.java
@@ -18,6 +18,7 @@ import com.shatyuka.zhiliao.hooks.HotBanner;
 import com.shatyuka.zhiliao.hooks.IHook;
 import com.shatyuka.zhiliao.hooks.LaunchAd;
 import com.shatyuka.zhiliao.hooks.LiveButton;
+import com.shatyuka.zhiliao.hooks.MineHybridView;
 import com.shatyuka.zhiliao.hooks.NavButton;
 import com.shatyuka.zhiliao.hooks.NavRes;
 import com.shatyuka.zhiliao.hooks.NextAnswer;
@@ -61,7 +62,8 @@ public class Hooks {
             new WebView(),
             new Cleaner(),
             new FeedTopHotBanner(),
-            new HeadZoneBanner()
+            new HeadZoneBanner(),
+            new MineHybridView()
     };
 
     public static void init(final ClassLoader classLoader) {

--- a/app/src/main/java/com/shatyuka/zhiliao/hooks/CustomTabFilter.java
+++ b/app/src/main/java/com/shatyuka/zhiliao/hooks/CustomTabFilter.java
@@ -1,0 +1,103 @@
+package com.shatyuka.zhiliao.hooks;
+
+import com.shatyuka.zhiliao.Helper;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedBridge;
+
+
+public class CustomTabFilter implements IHook {
+
+    static Class<?> mainPageFragment;
+
+    static Field customTabInfoList;
+
+    static Field tabType;
+
+    @Override
+    public String getName() {
+        return "自定义首页顶栏Tab";
+    }
+
+    @Override
+    public void init(ClassLoader classLoader) throws Throwable {
+        mainPageFragment = classLoader.loadClass("com.zhihu.android.app.feed.explore.view.MainPageFragment");
+
+        customTabInfoList = Arrays.stream(mainPageFragment.getDeclaredFields())
+                .filter(field -> field.getType() == List.class).findFirst().get();
+        customTabInfoList.setAccessible(true);
+
+        tabType = classLoader.loadClass("com.zhihu.android.api.model.CustomTabInfo").getDeclaredField("tab_type");
+        tabType.setAccessible(true);
+    }
+
+    @Override
+    public void hook() throws Throwable {
+        if (Helper.prefs.getBoolean("switch_mainswitch", false)) {
+            XposedBridge.hookAllMethods(mainPageFragment, "onCreate", new XC_MethodHook() {
+                @Override
+                protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+
+                    List<Object> tabList = (List<Object>) customTabInfoList.get(param.thisObject);
+
+                    String tabFilter = Helper.prefs.getString("edit_tabfilter", "");
+                    if (tabFilter.isEmpty()) {
+                        Helper.prefs.edit().putString("edit_tabfilter", encodePattern(tabList)).apply();
+                    } else {
+                        List<Object> postProcessTabList = postProcessTabList(tabList, decodePattern(tabFilter));
+                        customTabInfoList.set(param.thisObject, postProcessTabList);
+                    }
+                }
+
+            });
+        }
+    }
+
+    private String encodePattern(List<Object> tabList) {
+        if (tabList == null || tabList.isEmpty()) {
+            return null;
+        }
+        return tabList.stream().map(o -> {
+                    try {
+                        return (String) tabType.get(o);
+                    } catch (IllegalAccessException e) {
+                        return null;
+                    }
+                }).filter(s -> s != null && !s.isEmpty())
+                .collect(Collectors.joining("|"));
+    }
+
+    private List<String> decodePattern(String pattern) {
+        return Arrays.stream(pattern.split("\\|"))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    private List<Object> postProcessTabList(List<Object> tabList, List<String> typeFilterList) {
+        if (tabList == null || tabList.isEmpty()) {
+            return tabList;
+        }
+
+        Map<String, Object> typeTabMap = tabList.stream()
+                .collect(Collectors.toMap(tab -> {
+                    try {
+                        return (String) tabType.get(tab);
+                    } catch (IllegalAccessException ignore) {
+                        return null;
+                    }
+                }, tab -> tab));
+
+        return typeFilterList.stream()
+                .map(typeTabMap::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+}

--- a/app/src/main/java/com/shatyuka/zhiliao/hooks/FeedTopHotBanner.java
+++ b/app/src/main/java/com/shatyuka/zhiliao/hooks/FeedTopHotBanner.java
@@ -1,0 +1,32 @@
+package com.shatyuka.zhiliao.hooks;
+
+import com.shatyuka.zhiliao.Helper;
+
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedBridge;
+
+public class FeedTopHotBanner implements IHook {
+    static Class<?> feedTopHotAutoJacksonDeserializer;
+
+    @Override
+    public String getName() {
+        return "隐藏推荐页置顶热门";
+    }
+
+    @Override
+    public void init(ClassLoader classLoader) throws Throwable {
+        feedTopHotAutoJacksonDeserializer = classLoader.loadClass("com.zhihu.android.api.model.FeedTopHotAutoJacksonDeserializer");
+    }
+
+    @Override
+    public void hook() throws Throwable {
+        XposedBridge.hookAllMethods(feedTopHotAutoJacksonDeserializer, "deserialize", new XC_MethodHook() {
+            @Override
+            protected void beforeHookedMethod(MethodHookParam param) {
+                if (Helper.prefs.getBoolean("switch_mainswitch", false) && Helper.prefs.getBoolean("switch_feedtophot", false)) {
+                    param.setResult(null);
+                }
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/shatyuka/zhiliao/hooks/HeadZoneBanner.java
+++ b/app/src/main/java/com/shatyuka/zhiliao/hooks/HeadZoneBanner.java
@@ -1,0 +1,40 @@
+package com.shatyuka.zhiliao.hooks;
+
+import com.shatyuka.zhiliao.Helper;
+
+import java.lang.reflect.Field;
+
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedBridge;
+
+public class HeadZoneBanner implements IHook {
+    static Class<?> rankFeedList;
+    static Class<?> feedsHotListFragment2;
+
+    static Field head_zone;
+
+    @Override
+    public String getName() {
+        return "隐藏热榜顶部置顶";
+    }
+
+    @Override
+    public void init(ClassLoader classLoader) throws Throwable {
+        rankFeedList = classLoader.loadClass("com.zhihu.android.api.model.RankFeedList");
+        head_zone = rankFeedList.getDeclaredField("head_zone");
+        head_zone.setAccessible(true);
+        feedsHotListFragment2 = classLoader.loadClass("com.zhihu.android.app.feed.ui.fragment.FeedsHotListFragment2");
+    }
+
+    @Override
+    public void hook() throws Throwable {
+        XposedBridge.hookAllMethods(feedsHotListFragment2, "postRefreshSucceed", new XC_MethodHook() {
+            @Override
+            protected void beforeHookedMethod(MethodHookParam param) throws IllegalAccessException {
+                if (Helper.prefs.getBoolean("switch_mainswitch", false)) {
+                    head_zone.set(param.args[0], null);
+                }
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/shatyuka/zhiliao/hooks/MineHybridView.java
+++ b/app/src/main/java/com/shatyuka/zhiliao/hooks/MineHybridView.java
@@ -1,0 +1,53 @@
+package com.shatyuka.zhiliao.hooks;
+
+import android.view.View;
+
+import com.shatyuka.zhiliao.Helper;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedBridge;
+
+public class MineHybridView implements IHook {
+
+    static Class<?> mineTabFragment;
+
+    static Class<?> mineHybridView;
+
+    static Field mineHybridViewField;
+
+    @Override
+    public String getName() {
+        return "隐藏「我的」底部混合卡片";
+    }
+
+    @Override
+    public void init(ClassLoader classLoader) throws Throwable {
+        mineTabFragment = classLoader.loadClass("com.zhihu.android.app.ui.fragment.more.mine.MineTabFragment");
+        mineHybridView = classLoader.loadClass("com.zhihu.android.app.ui.fragment.more.mine.widget.MineHybridView");
+
+        mineHybridViewField = Arrays.stream(mineTabFragment.getDeclaredFields()).filter(field -> field.getType() == mineHybridView).findFirst().get();
+        mineHybridViewField.setAccessible(true);
+
+    }
+
+    @Override
+    public void hook() throws Throwable {
+
+        XposedBridge.hookAllMethods(mineTabFragment, "onCreateView", new XC_MethodHook() {
+            @Override
+            protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+                if (Helper.prefs.getBoolean("switch_mainswitch", false) && Helper.prefs.getBoolean("switch_minehybrid", false)) {
+                    View mineHybridView = (View) mineHybridViewField.get(param.thisObject);
+                    if (mineHybridView != null) {
+                        mineHybridView.setVisibility(View.GONE);
+                    }
+                }
+            }
+        });
+
+
+    }
+}

--- a/app/src/main/java/com/shatyuka/zhiliao/hooks/NavButton.java
+++ b/app/src/main/java/com/shatyuka/zhiliao/hooks/NavButton.java
@@ -7,7 +7,6 @@ import com.shatyuka.zhiliao.Helper;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.List;
 
 import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XposedBridge;
@@ -29,29 +28,18 @@ public class NavButton implements IHook {
     public void init(ClassLoader classLoader) throws Throwable {
         BottomNavMenuView = classLoader.loadClass("com.zhihu.android.bottomnav.core.BottomNavMenuView");
 
-        List<String> classNameList = Arrays.asList(
-                "com.zhihu.android.bottomnav.core.a.b",
-                // 9.36.0 b.b#a
-                "com.zhihu.android.bottomnav.core.b.b",
-                "com.zhihu.android.bottomnav.core.t.g",
-                "com.zhihu.android.bottomnav.core.w.d",
-                // 9.37.0 r.g#getItemId
-                "com.zhihu.android.bottomnav.core.r.g");
 
-        for (String className : classNameList) {
-            try {
-                IMenuItem = classLoader.loadClass(className);
-                try {
-                    getItemId = IMenuItem.getMethod("getItemId");
-                } catch (NoSuchMethodException ignore) {
-                    getItemId = IMenuItem.getMethod("a");
-                }
-                break;
-            } catch (ClassNotFoundException ignore) {
-            }
-        }
+        Class<?> tabLayoutTabClass = classLoader.loadClass("com.google.android.material.tabs.TabLayout$Tab");
+        IMenuItem = Arrays.stream(BottomNavMenuView.getDeclaredMethods())
+                .filter(method -> method.getReturnType() == tabLayoutTabClass)
+                .map(method -> method.getParameterTypes()[0]).findFirst().get();
 
-        Tab_tabView = classLoader.loadClass("com.google.android.material.tabs.TabLayout$Tab").getField("view");
+
+        getItemId = Arrays.stream(IMenuItem.getDeclaredMethods())
+                .filter(method -> method.getReturnType() == String.class).findFirst().get();
+
+
+        Tab_tabView = tabLayoutTabClass.getField("view");
     }
 
     @Override

--- a/app/src/main/java/com/shatyuka/zhiliao/hooks/NavButton.java
+++ b/app/src/main/java/com/shatyuka/zhiliao/hooks/NavButton.java
@@ -6,10 +6,11 @@ import com.shatyuka.zhiliao.Helper;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
 
 import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XposedBridge;
-import de.robv.android.xposed.XposedHelpers;
 
 public class NavButton implements IHook {
     static Class<?> BottomNavMenuView;
@@ -27,24 +28,27 @@ public class NavButton implements IHook {
     @Override
     public void init(ClassLoader classLoader) throws Throwable {
         BottomNavMenuView = classLoader.loadClass("com.zhihu.android.bottomnav.core.BottomNavMenuView");
-        try {
-            IMenuItem = classLoader.loadClass("com.zhihu.android.bottomnav.core.a.b");
-        } catch (ClassNotFoundException e) {
-            try {
-                IMenuItem = classLoader.loadClass("com.zhihu.android.bottomnav.core.b.b");
-            } catch (ClassNotFoundException e2) {
-                try {
-                    IMenuItem = classLoader.loadClass("com.zhihu.android.bottomnav.core.t.g");
-                } catch (ClassNotFoundException e3) {
-                    IMenuItem = classLoader.loadClass("com.zhihu.android.bottomnav.core.w.d");
-                }
-            }
-        }
 
-        try {
-            getItemId = IMenuItem.getMethod("getItemId");
-        } catch (NoSuchMethodException e) {
-            getItemId = IMenuItem.getMethod("a");
+        List<String> classNameList = Arrays.asList(
+                "com.zhihu.android.bottomnav.core.a.b",
+                // 9.36.0 b.b#a
+                "com.zhihu.android.bottomnav.core.b.b",
+                "com.zhihu.android.bottomnav.core.t.g",
+                "com.zhihu.android.bottomnav.core.w.d",
+                // 9.37.0 r.g#getItemId
+                "com.zhihu.android.bottomnav.core.r.g");
+
+        for (String className : classNameList) {
+            try {
+                IMenuItem = classLoader.loadClass(className);
+                try {
+                    getItemId = IMenuItem.getMethod("getItemId");
+                } catch (NoSuchMethodException ignore) {
+                    getItemId = IMenuItem.getMethod("a");
+                }
+                break;
+            } catch (ClassNotFoundException ignore) {
+            }
         }
 
         Tab_tabView = classLoader.loadClass("com.google.android.material.tabs.TabLayout$Tab").getField("view");
@@ -52,14 +56,14 @@ public class NavButton implements IHook {
 
     @Override
     public void hook() throws Throwable {
-        if (Helper.prefs.getBoolean("switch_mainswitch", false) && (Helper.prefs.getBoolean("switch_vipnav", false) || Helper.prefs.getBoolean("switch_videonav", false)|| Helper.prefs.getBoolean("switch_friendnav", false) || Helper.prefs.getBoolean("switch_panelnav", false))) {
+        if (Helper.prefs.getBoolean("switch_mainswitch", false) && (Helper.prefs.getBoolean("switch_vipnav", false) || Helper.prefs.getBoolean("switch_videonav", false) || Helper.prefs.getBoolean("switch_friendnav", false) || Helper.prefs.getBoolean("switch_panelnav", false))) {
             XposedBridge.hookMethod(Helper.getMethodByParameterTypes(BottomNavMenuView, IMenuItem), new XC_MethodHook() {
                 @Override
                 protected void afterHookedMethod(MethodHookParam param) throws Throwable {
                     if (("market".equals(getItemId.invoke(param.args[0])) && Helper.prefs.getBoolean("switch_vipnav", false)) ||
                             ("video".equals(getItemId.invoke(param.args[0])) && Helper.prefs.getBoolean("switch_videonav", false)) ||
                             ("friend".equals(getItemId.invoke(param.args[0])) && Helper.prefs.getBoolean("switch_friendnav", false)) ||
-                            ("panel".equals(getItemId.invoke(param.args[0]))&& Helper.prefs.getBoolean("switch_panelnav", false))){
+                            ("panel".equals(getItemId.invoke(param.args[0])) && Helper.prefs.getBoolean("switch_panelnav", false))) {
                         ((View) Tab_tabView.get(param.getResult())).setVisibility(View.GONE);
                     }
                 }

--- a/app/src/main/java/com/shatyuka/zhiliao/hooks/VIPBanner.java
+++ b/app/src/main/java/com/shatyuka/zhiliao/hooks/VIPBanner.java
@@ -39,7 +39,7 @@ public class VIPBanner implements IHook {
         }
 
         try {
-            MoreVipData = classLoader.loadClass("com.zhihu.android.profile.data.model.MoreVipData");
+            MoreVipData = classLoader.loadClass("com.zhihu.android.api.MoreVipData");
             NewMoreFragment = classLoader.loadClass("com.zhihu.android.app.ui.fragment.more.more.NewMoreFragment");
         } catch (ClassNotFoundException ignored) {
         }
@@ -80,6 +80,9 @@ public class VIPBanner implements IHook {
             if (MoreVipData != null && NewMoreFragment != null) {
                 XposedHelpers.findAndHookMethod(NewMoreFragment, "a", MoreVipData, XC_MethodReplacement.returnConstant(null));
             }
+
+            XposedBridge.hookAllMethods(MoreVipData, "isLegal", XC_MethodReplacement.returnConstant(Boolean.FALSE));
+
         }
     }
 }

--- a/app/src/main/java/com/shatyuka/zhiliao/hooks/ZhihuPreference.java
+++ b/app/src/main/java/com/shatyuka/zhiliao/hooks/ZhihuPreference.java
@@ -29,6 +29,8 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.Random;
 
 import de.robv.android.xposed.XC_MethodHook;
@@ -142,10 +144,8 @@ public class ZhihuPreference implements IHook {
             getKey = Preference.getMethod("C");
             setChecked = SwitchPreference.getMethod("g", boolean.class);
             getText = EditTextPreference.getMethod("i");
-            getLayoutResId_MethodName = "i";
             getResourceId_MethodName = "v";
-            onCreate_MethodName = "h";
-        } catch (NoSuchMethodException e) {
+        } catch (NoSuchMethodException ignore) {
             findPreference = Helper.getMethodByParameterTypes(BasePreferenceFragment.getSuperclass(), CharSequence.class);
             setSummary = Preference.getMethod("B0", CharSequence.class);
             setIcon = Preference.getMethod("r0", Drawable.class);
@@ -153,10 +153,19 @@ public class ZhihuPreference implements IHook {
             getKey = Preference.getMethod("o");
             setChecked = SwitchPreference.getMethod("O0", boolean.class);
             getText = EditTextPreference.getMethod("R0");
-            getLayoutResId_MethodName = "vg";
             getResourceId_MethodName = "p";
-            onCreate_MethodName = "xg";
         }
+
+        getLayoutResId_MethodName = Arrays.stream(BasePreferenceFragment.getDeclaredMethods())
+                .filter(method -> Modifier.isAbstract(method.getModifiers())
+                        && method.getReturnType() == int.class
+                        && method.getParameterCount() == 0).findFirst().get().getName();
+
+        onCreate_MethodName = Arrays.stream(BasePreferenceFragment.getDeclaredMethods())
+                .filter(method -> Modifier.isAbstract(method.getModifiers())
+                        && method.getReturnType() == void.class
+                        && method.getParameterCount() == 0).findFirst().get().getName();
+
         setOnPreferenceChangeListener = Helper.getMethodByParameterTypes(Preference, OnPreferenceChangeListener);
         setOnPreferenceClickListener = Helper.getMethodByParameterTypes(Preference, OnPreferenceClickListener);
         try {
@@ -197,9 +206,9 @@ public class ZhihuPreference implements IHook {
             SeekBarPreference_mSeekBarValueTextView.setAccessible(true);
             OnSeekBarChangeListener_seekBarPreferenceInstance = OnSeekBarChangeListener.getDeclaredField("j");
             OnSeekBarChangeListener_seekBarPreferenceInstance.setAccessible(true);
-            ListPreference_mEntries = ListPreference.getDeclaredField("s0");
+            ListPreference_mEntries = ListPreference.getDeclaredFields()[0];
             ListPreference_mEntries.setAccessible(true);
-            ListPreference_mEntryValues = ListPreference.getDeclaredField("t0");
+            ListPreference_mEntryValues = ListPreference.getDeclaredFields()[1];
             ListPreference_mEntryValues.setAccessible(true);
         }
 

--- a/app/src/main/java/com/shatyuka/zhiliao/hooks/ZhihuPreference.java
+++ b/app/src/main/java/com/shatyuka/zhiliao/hooks/ZhihuPreference.java
@@ -400,6 +400,7 @@ public class ZhihuPreference implements IHook {
                 Object preference_clean = findPreference.invoke(thisObject, "preference_clean");
                 Object switch_autoclean = findPreference.invoke(thisObject, "switch_autoclean");
                 Object switch_feedtophot = findPreference.invoke(thisObject, "switch_feedtophot");
+                Object switch_minehybrid = findPreference.invoke(thisObject, "switch_minehybrid");
 
                 setOnPreferenceChangeListener.invoke(findPreference.invoke(thisObject, "accept_eula"), thisObject);
                 setOnPreferenceClickListener.invoke(switch_externlink, thisObject);
@@ -428,6 +429,7 @@ public class ZhihuPreference implements IHook {
                 setOnPreferenceClickListener.invoke(preference_sourcecode, thisObject);
                 setOnPreferenceClickListener.invoke(preference_donate, thisObject);
                 setOnPreferenceClickListener.invoke(switch_feedtophot, thisObject);
+                setOnPreferenceClickListener.invoke(switch_minehybrid, thisObject);
 
                 String real_version = null;
                 try {
@@ -514,6 +516,7 @@ public class ZhihuPreference implements IHook {
                 setIcon.invoke(preference_sourcecode, Helper.modRes.getDrawable(R.drawable.ic_github));
                 setIcon.invoke(preference_donate, Helper.modRes.getDrawable(R.drawable.ic_monetization));
                 setIcon.invoke(findPreference.invoke(thisObject, "switch_feedtophot"), Helper.modRes.getDrawable(R.drawable.ic_whatshot));
+                setIcon.invoke(findPreference.invoke(thisObject, "switch_minehybrid"), Helper.modRes.getDrawable(R.drawable.ic_viewcard));
 
                 if (Helper.prefs.getBoolean("accept_eula", false)) {
                     Object category_eula = findPreference.invoke(thisObject, "category_eula");
@@ -607,6 +610,7 @@ public class ZhihuPreference implements IHook {
                     case "switch_nipple":
                     case "switch_autoclean":
                     case "switch_feedtophot":
+                    case "switch_minehybrid":
                         Helper.toast("重启知乎生效", Toast.LENGTH_SHORT);
                         break;
                 }

--- a/app/src/main/java/com/shatyuka/zhiliao/hooks/ZhihuPreference.java
+++ b/app/src/main/java/com/shatyuka/zhiliao/hooks/ZhihuPreference.java
@@ -390,6 +390,7 @@ public class ZhihuPreference implements IHook {
                 Object switch_nextanswer = findPreference.invoke(thisObject, "switch_nextanswer");
                 Object preference_clean = findPreference.invoke(thisObject, "preference_clean");
                 Object switch_autoclean = findPreference.invoke(thisObject, "switch_autoclean");
+                Object switch_feedtophot = findPreference.invoke(thisObject, "switch_feedtophot");
 
                 setOnPreferenceChangeListener.invoke(findPreference.invoke(thisObject, "accept_eula"), thisObject);
                 setOnPreferenceClickListener.invoke(switch_externlink, thisObject);
@@ -417,6 +418,7 @@ public class ZhihuPreference implements IHook {
                 setOnPreferenceClickListener.invoke(preference_telegram, thisObject);
                 setOnPreferenceClickListener.invoke(preference_sourcecode, thisObject);
                 setOnPreferenceClickListener.invoke(preference_donate, thisObject);
+                setOnPreferenceClickListener.invoke(switch_feedtophot, thisObject);
 
                 String real_version = null;
                 try {
@@ -502,6 +504,7 @@ public class ZhihuPreference implements IHook {
                 setIcon.invoke(preference_telegram, Helper.modRes.getDrawable(R.drawable.ic_telegram));
                 setIcon.invoke(preference_sourcecode, Helper.modRes.getDrawable(R.drawable.ic_github));
                 setIcon.invoke(preference_donate, Helper.modRes.getDrawable(R.drawable.ic_monetization));
+                setIcon.invoke(findPreference.invoke(thisObject, "switch_feedtophot"), Helper.modRes.getDrawable(R.drawable.ic_whatshot));
 
                 if (Helper.prefs.getBoolean("accept_eula", false)) {
                     Object category_eula = findPreference.invoke(thisObject, "category_eula");
@@ -594,6 +597,7 @@ public class ZhihuPreference implements IHook {
                     case "switch_nextanswer":
                     case "switch_nipple":
                     case "switch_autoclean":
+                    case "switch_feedtophot":
                         Helper.toast("重启知乎生效", Toast.LENGTH_SHORT);
                         break;
                 }

--- a/app/src/main/java/com/shatyuka/zhiliao/hooks/ZhihuPreference.java
+++ b/app/src/main/java/com/shatyuka/zhiliao/hooks/ZhihuPreference.java
@@ -401,6 +401,7 @@ public class ZhihuPreference implements IHook {
                 Object switch_autoclean = findPreference.invoke(thisObject, "switch_autoclean");
                 Object switch_feedtophot = findPreference.invoke(thisObject, "switch_feedtophot");
                 Object switch_minehybrid = findPreference.invoke(thisObject, "switch_minehybrid");
+                Object edit_tabfilter = findPreference.invoke(thisObject, "edit_tabfilter");
 
                 setOnPreferenceChangeListener.invoke(findPreference.invoke(thisObject, "accept_eula"), thisObject);
                 setOnPreferenceClickListener.invoke(switch_externlink, thisObject);
@@ -430,6 +431,7 @@ public class ZhihuPreference implements IHook {
                 setOnPreferenceClickListener.invoke(preference_donate, thisObject);
                 setOnPreferenceClickListener.invoke(switch_feedtophot, thisObject);
                 setOnPreferenceClickListener.invoke(switch_minehybrid, thisObject);
+                setOnPreferenceChangeListener.invoke(edit_tabfilter, thisObject);
 
                 String real_version = null;
                 try {
@@ -517,6 +519,7 @@ public class ZhihuPreference implements IHook {
                 setIcon.invoke(preference_donate, Helper.modRes.getDrawable(R.drawable.ic_monetization));
                 setIcon.invoke(findPreference.invoke(thisObject, "switch_feedtophot"), Helper.modRes.getDrawable(R.drawable.ic_whatshot));
                 setIcon.invoke(findPreference.invoke(thisObject, "switch_minehybrid"), Helper.modRes.getDrawable(R.drawable.ic_viewcard));
+                setIcon.invoke(findPreference.invoke(thisObject, "edit_tabfilter"), Helper.modRes.getDrawable(R.drawable.ic_filter));
 
                 if (Helper.prefs.getBoolean("accept_eula", false)) {
                     Object category_eula = findPreference.invoke(thisObject, "category_eula");
@@ -620,12 +623,22 @@ public class ZhihuPreference implements IHook {
         XposedBridge.hookMethod(Helper.getMethodByParameterTypes(DebugFragment, Preference, Object.class), new XC_MethodReplacement() {
             @Override
             protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
-                if ((boolean) param.args[1]) {
-                    Object switch_main = findPreference.invoke(param.thisObject, "switch_mainswitch");
-                    setChecked.invoke(switch_main, true);
-                    Object category_eula = findPreference.invoke(param.thisObject, "category_eula");
-                    setVisible.invoke(category_eula, false);
+                if (param.args[0].getClass() == SwitchPreference) {
+                    if (param.args[1] instanceof Boolean) {
+                        if ((boolean) param.args[1]) {
+                            Object switch_main = findPreference.invoke(param.thisObject, "switch_mainswitch");
+                            setChecked.invoke(switch_main, true);
+                            Object category_eula = findPreference.invoke(param.thisObject, "category_eula");
+                            setVisible.invoke(category_eula, false);
+                        }
+                    }
+                } else if (param.args[0].getClass() == EditTextPreference) {
+                    String key = (String) getKey.invoke(param.args[0]);
+                    if ("edit_tabfilter".equals(key)) {
+                        Helper.toast("重启知乎生效", Toast.LENGTH_SHORT);
+                    }
                 }
+
                 return true;
             }
         });

--- a/app/src/main/res/drawable/ic_filter.xml
+++ b/app/src/main/res/drawable/ic_filter.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#808080"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M10.83,8H21V6H8.83L10.83,8zM15.83,13H18v-2h-4.17L15.83,13zM14,16.83V18h-4v-2h3.17l-3,-3H6v-2h2.17l-3,-3H3V6h0.17L1.39,4.22l1.41,-1.41l18.38,18.38l-1.41,1.41L14,16.83z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_viewcard.xml
+++ b/app/src/main/res/drawable/ic_viewcard.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#808080"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M21,18L2,18v2h19v-2zM19,10v4L4,14v-4h15m1,-2L3,8c-0.55,0 -1,0.45 -1,1v6c0,0.55 0.45,1 1,1h17c0.55,0 1,-0.45 1,-1L21,9c0,-0.55 -0.45,-1 -1,-1zM21,4L2,4v2h19L21,4z"/>
+</vector>

--- a/app/src/main/res/xml/preferences_zhihu.xml
+++ b/app/src/main/res/xml/preferences_zhihu.xml
@@ -217,6 +217,12 @@
             android:key="switch_nipple"
             android:title="隐藏导航栏突起"
             android:summary="隐藏奇奇怪怪的突出部"/>
+        <com.zhihu.android.app.ui.widget.SwitchPreference
+            android:defaultValue="false"
+            android:dependency="switch_mainswitch"
+            android:key="switch_feedtophot"
+            android:title="隐藏置顶热门"
+            android:summary="隐藏推荐页顶部热门推荐"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="左右划" android:key="category_swap_answers">
         <com.zhihu.android.app.ui.widget.SwitchPreference

--- a/app/src/main/res/xml/preferences_zhihu.xml
+++ b/app/src/main/res/xml/preferences_zhihu.xml
@@ -223,6 +223,12 @@
             android:key="switch_feedtophot"
             android:title="隐藏置顶热门"
             android:summary="隐藏推荐页顶部热门推荐"/>
+        <com.zhihu.android.app.ui.widget.SwitchPreference
+            android:defaultValue="false"
+            android:dependency="switch_mainswitch"
+            android:key="switch_minehybrid"
+            android:title="隐藏混合卡片"
+            android:summary="隐藏「我的」底部混合卡片"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="左右划" android:key="category_swap_answers">
         <com.zhihu.android.app.ui.widget.SwitchPreference

--- a/app/src/main/res/xml/preferences_zhihu.xml
+++ b/app/src/main/res/xml/preferences_zhihu.xml
@@ -229,6 +229,12 @@
             android:key="switch_minehybrid"
             android:title="隐藏混合卡片"
             android:summary="隐藏「我的」底部混合卡片"/>
+        <EditTextPreference
+            android:defaultValue=""
+            android:dependency="switch_mainswitch"
+            android:key="edit_tabfilter"
+            android:title="自定义首页顶栏Tab"
+            android:summary="使用 | 隔开, 留空则忽略"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="左右划" android:key="category_swap_answers">
         <com.zhihu.android.app.ui.widget.SwitchPreference


### PR DESCRIPTION
1. 新增隐藏推荐页顶部热门推荐
2. 新增隐藏热榜顶部置顶功能
3. 新增隐藏「我的」底部混合卡片
4. 新增自定义首页顶栏Tab
5. fix: 隐藏导航栏失效
6. fix: 知了设置不显示(9.37.0)
7. fix: 隐藏会员卡片


## after:
<img src="https://github.com/shatyuka/Zhiliao/assets/78064276/efa91ce6-c285-46d6-a929-ab4c4c3cff2f" width="251px">

<img src="https://github.com/CLOUDERHEM/Zhiliao/assets/78064276/736c8423-7dad-489e-895a-1650c5b85a3b" width="251px">

<img src="https://github.com/shatyuka/Zhiliao/assets/78064276/0cb91be6-3dfa-4b91-963f-3df0a374cbfc" width="251px">


